### PR TITLE
Fix Insecure Content Warning

### DIFF
--- a/common/header.php
+++ b/common/header.php
@@ -22,7 +22,7 @@
 
     <!-- Stylesheets -->
     <?php
-    queue_css_url('http://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700,300italic,400italic,500italic,700italic');
+    queue_css_url('//fonts.googleapis.com/css?family=Ubuntu:300,400,500,700,300italic,400italic,500italic,700italic');
     queue_css_file('normalize');
     queue_css_file('style', 'screen');
     queue_css_file('print', 'print');


### PR DESCRIPTION
Removed the http:// from the non https:// links and changed to the agnostic // style. Where it will pick the transport layer that is being used for browsing.

If browsing http:// it will assume http://. If browsing https:// it will assume https://
